### PR TITLE
Fix AllowTrust operation

### DIFF
--- a/lib/stellar/base/allow_trust_asset.ex
+++ b/lib/stellar/base/allow_trust_asset.ex
@@ -1,0 +1,86 @@
+defmodule Stellar.Base.AllowTrustAsset do
+  alias Stellar.XDR.Types.{
+    AssetTypeCreditAlphaNum4,
+    AssetTypeCreditAlphaNum12,
+    Asset
+  }
+
+  @doc """
+  This function decodes the XDR Asset to String
+    ##Parameters
+      - code: represents the XDR structure of the asset code
+  """
+  @spec from_xdr(tuple()) :: String.t()
+  def from_xdr({_, %{assetCode4: code}}),
+    do: code |> String.trim_trailing("\0")
+
+  @doc """
+  This function decodes the XDR Asset to String
+    ##Parameters
+      - code: represents the XDR structure of the asset code
+  """
+  @spec from_xdr(tuple()) :: String.t()
+  def from_xdr({_, %{assetCode12: code}}),
+    do: code |> String.trim_trailing("\0")
+
+  @doc """
+  This function gets the case when the asset code value is nil
+  returns an error tuple with the description of the error
+  """
+  @spec to_xdr(nil) :: {:error, String.t()}
+  def to_xdr(nil), do: {:error, "Asset code cannot be nil"}
+
+  @doc """
+  This function encode the asset that needs the AllowTrust operation, this Asset contains the data required to perform the operation
+    ##Parameters
+    - asset: Represents the Asset code of the AllowTrust
+  returns an Asset structure with the type of the Asset and its details
+  """
+  @spec to_xdr(asset :: String.t()) :: Asset.t()
+  def to_xdr(asset) do
+    asset_params =
+      case asset_type(asset) do
+        "native" ->
+          {:ASSET_TYPE_NATIVE, nil}
+
+        "credit_alphanum4" ->
+          with {:ok, asset_details} <-
+                 %AssetTypeCreditAlphaNum4{
+                   assetCode4: asset |> String.pad_trailing(4, "\0")
+                 }
+                 |> AssetTypeCreditAlphaNum4.new() do
+            {:ASSET_TYPE_CREDIT_ALPHANUM4, asset_details}
+          end
+
+        "credit_alphanum12" ->
+          with {:ok, asset_details} <-
+                 %AssetTypeCreditAlphaNum12{
+                   assetCode12: asset |> String.pad_trailing(12, "\0")
+                 }
+                 |> AssetTypeCreditAlphaNum12.new() do
+            {:ASSET_TYPE_CREDIT_ALPHANUM12, asset_details}
+          end
+      end
+
+    with {:ok, result} <- Asset.new(asset_params) do
+      result
+    else
+      err -> err
+    end
+  end
+
+  @spec asset_type(String.t()) :: String.t()
+  defp asset_type("XML") do
+    "native"
+  end
+
+  @spec asset_type(code :: String.t()) :: String.t()
+  defp asset_type(code) when byte_size(code) >= 1 and byte_size(code) <= 4 do
+    "credit_alphanum4"
+  end
+
+  @spec asset_type(any()) :: String.t()
+  defp asset_type(_) do
+    "credit_alphanum12"
+  end
+end

--- a/lib/stellar/base/transaction_builder.ex
+++ b/lib/stellar/base/transaction_builder.ex
@@ -76,8 +76,7 @@ defmodule Stellar.Base.TransactionBuilder do
 
   def build(this) do
     with updated_source_account <- Account.increment_sequence_number(this.source_account),
-         {:ok, xdr_transaction} <-
-           build_transaction_xdr(this, updated_source_account),
+         {:ok, xdr_transaction} <- build_transaction_xdr(this, updated_source_account),
          {:ok, xenv} <- build_transaction_envelope(xdr_transaction),
          %Transaction{} = tx <- Transaction.new(xenv) do
       {:ok, tx, updated_source_account}

--- a/lib/stellar/xdr/types/transaction.ex
+++ b/lib/stellar/xdr/types/transaction.ex
@@ -34,6 +34,7 @@ defmodule Stellar.XDR.Types.Transaction do
     String64
   }
 
+  alias Stellar.XDR.Types.Asset, as: AllowAsset
   alias PublicKey, as: AccountID
 
   defmodule DecoratedSignature do
@@ -140,7 +141,7 @@ defmodule Stellar.XDR.Types.Transaction do
   defmodule AllowTrustOp do
     use Struct,
       trustor: AccountID,
-      asset: Asset,
+      asset: AllowAsset,
       authorize: Bool
   end
 
@@ -194,7 +195,7 @@ defmodule Stellar.XDR.Types.Transaction do
   end
 
   defmodule MemoText do
-    use XDR.Type.String, max_len: 28 
+    use XDR.Type.String, max_len: 28
   end
 
   defmodule Memo do

--- a/lib/stellar/xdr/types/types.ex
+++ b/lib/stellar/xdr/types/types.ex
@@ -1,6 +1,7 @@
 defmodule Stellar.XDR.Types do
   alias XDR.Type.{
     Enum,
+    Struct,
     FixedOpaque,
     HyperInt,
     HyperUint,
@@ -116,5 +117,40 @@ defmodule Stellar.XDR.Types do
   defmodule HmacSha256Mac do
     use XDR.Type.Struct,
       mac: Key32
+  end
+
+  defmodule AssetType do
+    use Enum,
+      ASSET_TYPE_NATIVE: 0,
+      ASSET_TYPE_CREDIT_ALPHANUM4: 1,
+      ASSET_TYPE_CREDIT_ALPHANUM12: 2
+  end
+
+  defmodule AssetCode4 do
+    use FixedOpaque, len: 4
+  end
+
+  defmodule AssetCode12 do
+    use FixedOpaque, len: 12
+  end
+
+  defmodule AssetTypeCreditAlphaNum4 do
+    use Struct,
+      assetCode4: AssetCode4
+  end
+
+  defmodule AssetTypeCreditAlphaNum12 do
+    use Struct,
+      assetCode12: AssetCode12
+  end
+
+  defmodule Asset do
+    use Union,
+      switch: AssetType,
+      cases: [
+        ASSET_TYPE_NATIVE: Void,
+        ASSET_TYPE_CREDIT_ALPHANUM4: AssetTypeCreditAlphaNum4,
+        ASSET_TYPE_CREDIT_ALPHANUM12: AssetTypeCreditAlphaNum12
+      ]
   end
 end

--- a/test/stellar/base/account_test.exs
+++ b/test/stellar/base/account_test.exs
@@ -24,8 +24,7 @@ defmodule Stellar.Base.Account.Test do
       assert Stellar.Base.Account.accountId(account) ==
                "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB"
 
-      assert Stellar.Base.Account.sequence_number(account) ==
-               100
+      assert Stellar.Base.Account.sequence_number(account) == 100
     end
   end
 

--- a/test/stellar/base/allow_trust_asset_test.exs
+++ b/test/stellar/base/allow_trust_asset_test.exs
@@ -1,0 +1,43 @@
+defmodule Stellar.Base.AllowTrustAsset.Test do
+  use ExUnit.Case, async: true
+
+  alias Stellar.Base.AllowTrustAsset
+
+  test "to xdr with ALPHANUM4" do
+    asset_code = "DCH"
+
+    result = AllowTrustAsset.to_xdr(asset_code)
+
+    assert elem(result, 0) == :ASSET_TYPE_CREDIT_ALPHANUM4
+    assert is_map(elem(result, 1)) == true
+  end
+
+  test "to xdr with ALPHANUM12" do
+    asset_code = "DCHHCD"
+
+    result = AllowTrustAsset.to_xdr(asset_code)
+
+    assert elem(result, 0) == :ASSET_TYPE_CREDIT_ALPHANUM12
+    assert is_map(elem(result, 1)) == true
+  end
+
+  test "from xdr ALPHANUM4" do
+    asset_code = "DCH"
+
+    result =
+      AllowTrustAsset.to_xdr(asset_code)
+      |> AllowTrustAsset.from_xdr()
+
+    assert result == asset_code
+  end
+
+  test "from xdr ALPHANUM12" do
+    asset_code = "DCHHCD"
+
+    result =
+      AllowTrustAsset.to_xdr(asset_code)
+      |> AllowTrustAsset.from_xdr()
+
+    assert result == asset_code
+  end
+end

--- a/test/stellar/base/transaction_builder_test.exs
+++ b/test/stellar/base/transaction_builder_test.exs
@@ -269,4 +269,53 @@ defmodule Stellar.Base.TransactionBuilder.Test do
       assert transaction.tx.timeBounds.maxTime == (DateTime.utc_now() |> DateTime.to_unix()) + 10
     end
   end
+
+  describe "Construct allow trust operation" do
+    setup do
+      %{
+        source: Account.new("GAYIVSXCNALI3D7P5ROBJ7Q6I4QN6APVRU7CONUP7U6IKJJRPGKYM4EY", 0),
+        trustor: "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F"
+      }
+    end
+
+    test "Build Alphanum12 allow trust", %{source: source, trustor: trustor} do
+      asset_code = "DCHHCD"
+
+      {:ok, transaction, _} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.allow_trust(%{
+            trustor: trustor,
+            asset_code: asset_code,
+            authorize: true
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert List.first(transaction.operations).type == "allowTrust"
+      assert List.first(transaction.operations).trustor == trustor
+      assert List.first(transaction.operations).assetCode == asset_code
+    end
+
+    test "Build Alphanum4 allow trust", %{source: source, trustor: trustor} do
+      asset_code = "DCH"
+
+      {:ok, transaction, _} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.allow_trust(%{
+            trustor: trustor,
+            asset_code: asset_code,
+            authorize: true
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert List.first(transaction.operations).type == "allowTrust"
+      assert List.first(transaction.operations).trustor == trustor
+      assert List.first(transaction.operations).assetCode == asset_code
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** When an AllowTrust operation was performed, an error was raised, which is shown in the following picture:

![image](https://user-images.githubusercontent.com/53573555/70060014-c530ef00-15af-11ea-80ce-3f5d992db771.png)

After reviewing the code, we realized that the error was due to the Asset type used for the operation AllowTrust was not the correct. We solved the problem by applying the following changes:

1. **Added the new structs in Stellar.XDR.Types to the specific asset type of the AllowTrust operation**
- AssetCode4
- AssetCode12
- AssetTypeCreditAlphaNum4
- AssetTypeCreditAlphaNum12
- Asset

2. Modified the AllowTrustOp function in **Stellar.XDR.Types.Transaction** to use the new asset type

3. Added the module **Stellar.Base.AllowTrustAsset** to define the functions to encode and decode the asset struct for the AllowTrust operation.

4. Modified the flow functions on **Stellar.Base.Operation** to allow the new asset type

5. Added tests for building the AllowTrust operation