### PR TITLE
Add SetOptions operation

### DIFF
--- a/lib/stellar/base/operation.ex
+++ b/lib/stellar/base/operation.ex
@@ -1,6 +1,6 @@
 defmodule Stellar.Base.Operation do
   # https://github.com/stellar/js-stellar-base/tree/master/src/operations
-  alias Stellar.Base.{KeyPair, Asset, StrKey}
+  alias Stellar.Base.{KeyPair, Asset, StrKey, Signer}
 
   alias Stellar.XDR.Types.Transaction.{
     CreateAccountOp,
@@ -346,7 +346,7 @@ defmodule Stellar.Base.Operation do
       lowThreshold: set_options_op.lowThreshold,
       medThreshold: set_options_op.medThreshold,
       highThreshold: set_options_op.highThreshold,
-      signer: set_options_op.signer,
+      signer: set_options_op.signer |> Signer.from_xdr(),
       homeDomain: set_options_op.homeDomain
     }
   end
@@ -479,7 +479,7 @@ defmodule Stellar.Base.Operation do
              lowThreshold: this.lowThreshold,
              medThreshold: this.medThreshold,
              highThreshold: this.highThreshold,
-             signer: this.signer,
+             signer: this.signer |> Signer.to_xdr(),
              homeDomain: this.homeDomain
            }
            |> SetOptionsOp.new(),

--- a/lib/stellar/base/signer.ex
+++ b/lib/stellar/base/signer.ex
@@ -2,6 +2,75 @@ defmodule Stellar.Base.Signer do
   @type key :: binary
   @type signature :: binary
 
+  alias Stellar.XDR.Types.LedgerEntries.{Signer}
+  alias Stellar.XDR.Types.{SignerKey, UInt32}
+  alias Stellar.Base.{KeyPair, StrKey}
+
+  @doc """
+  This function allows the case when the singer to encode is nil
+  returns nil
+  """
+  @spec to_xdr(nil) :: nil
+  def to_xdr(nil), do: nil
+
+  @doc """
+  This function clause validates the weight of the new signer,this weight can't be greater than 255
+    ## Parameters
+    - Represents a map that contains the key and the weight of the signer which we need to add on SetOptions
+  returns an :error tuple with :invalid_weight atom
+  """
+  @spec to_xdr(map()) :: {:error, :invalid_weight}
+  def to_xdr(%{key: _, weight: weight}) when weight > 255, do: {:error, :invalid_weight}
+
+  @doc """
+  This function is in charge of encoding the signer to XDR format
+    ##Parameters
+    Represents a map that contains the key and the weight from the signer
+    - key: It is the public key of the signer which is necessary to add into the account
+    - weight: represents the weight of the signer to add
+  returns a signer in XDR format
+  """
+  @spec to_xdr(map()) :: Signer.t()
+  def to_xdr(%{key: key, weight: weight}) do
+    with {:ok, signer_account} <- KeyPair.from_public_key(key) |> to_xdr_accountid(),
+         {:ok, signer_weight} <- amount_to_xdr(weight) do
+      %Signer{key: signer_account, weight: signer_weight}
+    end
+  end
+
+  @doc """
+  This function gets the case where the signer to decode is nil
+  returns nil
+  """
+  @spec from_xdr(nil) :: nil
+  def from_xdr(nil), do: nil
+
+  @doc """
+  This function gets the Signer structure and decode from XDR format
+    ##Parameters
+    - signer: represents a Signer struct with the XDR info regarding the signer
+  Returns a map of the signer data in the default data type
+  """
+  @spec from_xdr(signer :: Signer.t()) :: map()
+  def from_xdr(signer) do
+    %{key: account_id_to_address(signer.key), weight: signer.weight}
+  end
+
+  @spec account_id_to_address(signer_account :: map()) :: String.t()
+  defp account_id_to_address({:SIGNER_KEY_TYPE_ED25519, signer_account}) do
+    signer_account |> StrKey.encode_ed25519_public_key()
+  end
+
+  @spec to_xdr_accountid(this :: map()) :: SignerKey.t()
+  defp to_xdr_accountid(this) do
+    SignerKey.new({:SIGNER_KEY_TYPE_ED25519, this._public_key})
+  end
+
+  @spec amount_to_xdr(amount :: number()) :: UInt32.t()
+  defp amount_to_xdr(amount) do
+    UInt32.new(amount)
+  end
+
   @spec sign(binary(), Ed25519.key()) :: signature()
   def sign(data, secret) do
     Ed25519.signature(data, secret)

--- a/lib/stellar/xdr/types/transaction.ex
+++ b/lib/stellar/xdr/types/transaction.ex
@@ -120,7 +120,7 @@ defmodule Stellar.XDR.Types.Transaction do
 
   defmodule SetOptionsOp do
     use Struct,
-      inflationDest: AccountID,
+      inflationDest: OptionalAccountID,
       clearFlags: OptionalUInt32,
       setFlags: OptionalUInt32,
       masterWeight: OptionalUInt32,
@@ -194,7 +194,7 @@ defmodule Stellar.XDR.Types.Transaction do
   end
 
   defmodule MemoText do
-    use XDR.Type.String, max_len: 28 
+    use XDR.Type.String, max_len: 28
   end
 
   defmodule Memo do

--- a/lib/stellar/xdr/types/transaction.ex
+++ b/lib/stellar/xdr/types/transaction.ex
@@ -6,7 +6,8 @@ defmodule Stellar.XDR.Types.Transaction do
     Struct,
     Union,
     Void,
-    VariableArray
+    VariableArray,
+    String
   }
 
   alias Stellar.XDR.Types.{
@@ -118,6 +119,10 @@ defmodule Stellar.XDR.Types.Transaction do
     use Optional, for: Signer
   end
 
+  defmodule OptionalString do
+    use Optional, for: String
+  end
+
   defmodule SetOptionsOp do
     use Struct,
       inflationDest: OptionalAccountID,
@@ -127,7 +132,7 @@ defmodule Stellar.XDR.Types.Transaction do
       lowThreshold: OptionalUInt32,
       medThreshold: OptionalUInt32,
       highThreshold: OptionalUInt32,
-      homeDomain: OptionalString32,
+      homeDomain: OptionalString,
       signer: OptionalSigner
   end
 

--- a/test/stellar/base/signer_test.exs
+++ b/test/stellar/base/signer_test.exs
@@ -68,4 +68,46 @@ defmodule Stellar.Signer.Test do
       assert Signer.verify(data, context[:bad_sig], context[:public_key]) == false
     end
   end
+
+  describe "Signer to XDR" do
+    test "parser a signer with an valid weight" do
+      result =
+        Enum.all?(0..255, fn weight ->
+          is_map(
+            Signer.to_xdr(%{
+              key: "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F",
+              weight: weight
+            })
+          )
+        end)
+
+      assert result == true
+    end
+
+    test "parse a signer with an invalid weight" do
+      {status, result} =
+        Signer.to_xdr(%{
+          key: "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F",
+          weight: 256
+        })
+
+      assert status == :error
+      assert result == :invalid_weight
+    end
+  end
+
+  test "Signer from XDR" do
+    signer = %Stellar.XDR.Types.LedgerEntries.Signer{
+      key:
+        {:SIGNER_KEY_TYPE_ED25519,
+         <<199, 91, 41, 236, 74, 168, 127, 251, 210, 99, 170, 165, 142, 121, 128, 133, 192, 254,
+           28, 214, 35, 19, 255, 1, 8, 240, 50, 189, 31, 93, 148, 151>>},
+      weight: 7
+    }
+
+    result = Signer.from_xdr(signer)
+
+    assert result.key == "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F"
+    assert result.weight == signer.weight
+  end
 end

--- a/test/stellar/base/transaction_builder_test.exs
+++ b/test/stellar/base/transaction_builder_test.exs
@@ -269,4 +269,177 @@ defmodule Stellar.Base.TransactionBuilder.Test do
       assert transaction.tx.timeBounds.maxTime == (DateTime.utc_now() |> DateTime.to_unix()) + 10
     end
   end
+
+  describe "SetOptions builder" do
+    setup do
+      %{
+        source: Account.new("GDRSG4KRN6SFM3C7NFRVB5Y3PR6OFEBY4TOP4EHLAAMZXRAWJMRBO4VE", 0)
+      }
+    end
+
+    test "build an inflation destination SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            inflation_dest: "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F"
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+
+      assert List.first(transaction.operations).inflationDest ==
+               "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F"
+
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a set flags SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            set_flags: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).setFlags == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a clear flags SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            clear_flags: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).clearFlags == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a Master weight SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            master_weight: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).masterWeight == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a Low threshold SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            low_threshold: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).lowThreshold == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a Medium threshold SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            med_threshold: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).medThreshold == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a High threshold SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            high_threshold: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).highThreshold == 1
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a Signer SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            signer: %{key: "GDDVWKPMJKUH766SMOVKLDTZQCC4B7Q42YRRH7YBBDYDFPI7LWKJP55F", weight: 1}
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert is_map(List.first(transaction.operations).signer) == true
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a Home domain SetOption", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            home_domain: "kommit.co"
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).homeDomain == "kommit.co"
+      assert updated_account._accountId == source._accountId
+    end
+
+    test "build a SetOption with multiple options", %{source: source} do
+      {status, transaction, updated_account} =
+        TransactionBuilder.new(source, [{:fee, 100}])
+        |> TransactionBuilder.add_operation(
+          Operation.set_options(%{
+            home_domain: "kommit.co",
+            high_threshold: 1
+          })
+        )
+        |> TransactionBuilder.set_timeout(10)
+        |> TransactionBuilder.build()
+
+      assert status == :ok
+      assert List.first(transaction.operations).homeDomain == "kommit.co"
+      assert List.first(transaction.operations).highThreshold == 1
+      assert updated_account._accountId == source._accountId
+    end
+  end
 end

--- a/test/stellar/base/transaction_test.exs
+++ b/test/stellar/base/transaction_test.exs
@@ -35,4 +35,32 @@ defmodule Stellar.Base.Transaction.Test do
     verified = signer |> KeyPair.verify(signed_transaction |> Transaction.hash(), raw_sig_details)
     assert verified == true
   end
+
+  test "signs set_options correctly" do
+    source =
+      Account.new("GDRSG4KRN6SFM3C7NFRVB5Y3PR6OFEBY4TOP4EHLAAMZXRAWJMRBO4VE", 29_888_677_412_932)
+
+    signer = KeyPair.from_secret("SDHPVJCQEFM5CJ4NDZYGZYOG3DXV35QHR5IQO3VR3BT2YTS2U3DZCJMB")
+
+    {:ok, transaction, _} =
+      TransactionBuilder.new(source, [{:fee, 100}])
+      |> TransactionBuilder.add_operation(
+        Operation.set_options(%{
+          master_weight: 3
+        })
+      )
+      |> TransactionBuilder.set_timeout(10)
+      |> TransactionBuilder.build()
+
+    signed_transaction =
+      transaction
+      |> Transaction.sign(signer)
+
+    env = signed_transaction |> Transaction.to_envelope()
+
+    raw_sig = env.signatures |> Enum.at(0)
+    raw_sig_details = raw_sig.signature
+    verified = signer |> KeyPair.verify(signed_transaction |> Transaction.hash(), raw_sig_details)
+    assert verified == true
+  end
 end


### PR DESCRIPTION
For implementing the SetOptions operation the following changes were done:

- Added the functions on **Stellar.Base.Operation** to allow the set options operation

- Added the functions on **Stellar.Base.Signer** for parsing the signer into XDR

- Modified the SetOptionsOp module on Stellar.XDR.Types.Transaction to allow the optional use of an inflation destination account

- Added tests for building the SetOptions transaction

- Added tests for parsing the signer into XDR

- Added tests for signing the setOptions operation